### PR TITLE
chore: add new go test workflow

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Checkout branch
         uses: actions/checkout@v3
-      # TODO: Discuss testing strategy and change this step accordingly 
+      # TODO: Discuss testing strategy and change this step accordingly
       # e.g. Test in Docker Image, Kind Cluster, ...
       - name: Set up Go for Tests
         uses: actions/setup-go@v4

--- a/.github/workflows/test-and-build.yaml
+++ b/.github/workflows/test-and-build.yaml
@@ -1,0 +1,35 @@
+name: Test, Build and Lint Go Package
+on:
+  push:
+    paths-ignore:
+      - 'test_actions/**'
+      - 'Dockerfile'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v3
+
+      - name: Set up Go for Tests
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.21
+
+      - name: Test
+        run: go test ./...
+
+      - name: Build
+        run: go build ./...
+
+      - name: Mod Verify
+        run: go mod verify
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.54


### PR DESCRIPTION
Ensure that tests, linters and build process run for every commit.

I am not sure if we should merge the two workflows and have a condition on the docker push steps or keep it like this. ATM I think having two workflows makes it cleaner.