### PR TITLE
refactor: remove metrics endpoint and scan interval

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,11 +1,9 @@
 package config
 
 import (
-	"time"
-
 	"github.com/SDA-SE/image-metadata-collector/internal/collector"
-	"github.com/SDA-SE/image-metadata-collector/internal/pkg/storage"
 	"github.com/SDA-SE/image-metadata-collector/internal/pkg/kubeclient"
+	"github.com/SDA-SE/image-metadata-collector/internal/pkg/storage"
 )
 
 type Config struct {
@@ -14,7 +12,5 @@ type Config struct {
 	kubeclient.KubeConfig
 	storage.StorageConfig
 
-	ScanInterval  time.Duration
-	Debug         bool
-	ExposeMetrics bool
+	Debug bool
 }


### PR DESCRIPTION
Removing the infinite loop here since we could not find a good reason to have it in the first place. This allows us to deploy the collector as a cron job and not have it running 24/7.
This change also made the metrics endpoint useless since it is no longer a long lived service.