### PR TITLE
chore: update quay.io repository name in build action

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -8,7 +8,7 @@ on:
 
 # TODO: After stable build on main is available, move to semantic versioning
 env:
-  REPOSITORY: quay.io/sdase/sdase-image-collector
+  REPOSITORY: quay.io/sdase/image-metadata-collector
   TAG: ${{ github.sha }}
 
 jobs:


### PR DESCRIPTION
Since we renamed the GH repository and project, we also created a new quay.io repository. Now we need to start pushing to that.

The new repository can be found [here](https://quay.io/repository/sdase/image-metadata-collector?namespace=sdase).