### PR TITLE
feat: add nobody as team default value

### DIFF
--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -98,7 +98,7 @@ func newCommand() *cobra.Command {
 	c.PersistentFlags().BoolVar(&cfg.CollectorImage.Skip, "skip", false, "Default behaviour for skipping scans for images")
 	c.PersistentFlags().StringSliceVar(&cfg.CollectorImage.EngagementTags, "engagement-tags", []string{}, "Default engagement tags to use")
 	c.PersistentFlags().StringVar(&cfg.CollectorImage.ContainerType, "container-type", "application", "Default container-type to use")
-	c.PersistentFlags().StringVar(&cfg.CollectorImage.Team, "team", "", "Default team to use")
+	c.PersistentFlags().StringVar(&cfg.CollectorImage.Team, "team", "nobody", "Default team to use")
 	c.PersistentFlags().StringVar(&cfg.CollectorImage.Product, "product", "", "Default product to use")
 	c.PersistentFlags().StringVar(&cfg.CollectorImage.Slack, "slack", "", "Default slack channel to use")
 	c.PersistentFlags().StringVar(&cfg.CollectorImage.Email, "email", "", "Default email to use")


### PR DESCRIPTION
DefectDojo has a problem when the team is not populated. The expectation is that the default is `nobody` instead of an empty string. This PR introduces this as a global default. The alternative would be to change this for the respective deployment e.g. [here](https://github.com/SDA-SE/terraform-nimbuskube/blob/main/modules/clusterscanner-collector/charts/clusterscanner-collector/templates/cronjob.yaml)