### PR TITLE
Added HTTP Header support for API requests

### DIFF
--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -54,6 +54,7 @@ func newCommand() *cobra.Command {
 	// Run Configuration
 	c.PersistentFlags().BoolVar(&cfg.Debug, "debug", false, "Set logging level to debug, default logging level is info")
 	c.Flags().StringSliceVarP(&cfg.RunConfig.ImageFilter, "image-filter", "s", []string{}, "Images to set the skip flag to true. Images as regex comma seperated without spaces. e.g. 'mock-service,mongo,openpolicyagent/opa,/istio/")
+
 	// Kubernetes Config
 	c.PersistentFlags().StringVar(&cfg.KubeConfig.ConfigFile, "kube-config", "", "absolute path to the kubeconfig file")
 	c.PersistentFlags().StringVar(&cfg.KubeConfig.Context, "kube-context", "", "The context to use to talk to the Kubernetes apiserver. If unset defaults to whatever your current-context is (kubectl config current-context)")
@@ -75,7 +76,10 @@ func newCommand() *cobra.Command {
 	c.PersistentFlags().StringVar(&cfg.StorageConfig.ApiKey, "api-key", "", "API Key")
 	c.PersistentFlags().StringVar(&cfg.StorageConfig.ApiSignature, "api-signature", "", "API Signature")
 	c.PersistentFlags().StringVar(&cfg.StorageConfig.ApiEndpoint, "api-endpoint", "", "API Endpoint, e.g. https://example.io/v1/account/$ACCOUNT/cluster/$CLUSTER/image-collector-report/images")
-
+	// HTTP Headers
+	// use like: AppName --http-headers "Authorization:Bearer token123,Content-Type:application/json"
+    c.Flags().StringSliceVar(&cfg.StorageConfig.HTTPHeaders, "http-headers", []string{}, "Comma-separated list of HTTP headers in 'key:value' format.")
+	
 	// Annotation Key/Name Config
 	c.PersistentFlags().StringVar(&cfg.AnnotationNames.Base, "annotation-name-base", "sdase.org/", "Annotation name for general annotations")
 	c.PersistentFlags().StringVar(&cfg.AnnotationNames.Scans, "annotation-name-scans", "clusterscanner.sdase.org/", "Annotation name for scan related annotations")
@@ -151,7 +155,6 @@ func run(cfg *config.Config) {
 	k8client := kubeclient.NewClient(&cfg.KubeConfig)
 
 	storage, err := storage.NewStorage(&cfg.StorageConfig, cfg.Environment)
-
 	if err != nil {
 		log.Fatal().Stack().Err(err).Msg("Could not create storage for: " + cfg.StorageConfig.StorageFlag)
 	}

--- a/internal/pkg/storage/storage.go
+++ b/internal/pkg/storage/storage.go
@@ -34,7 +34,8 @@ func NewStorage(cfg *StorageConfig, environment string) (io.Writer, error) {
 	case "s3":
 		w, err = s3.NewS3(&cfg.S3Config, filename)
 	case "api":
-		w = cfg.ApiConfig
+		//w = cfg.ApiConfig
+		w, err = api.NewApi(&cfg.ApiConfig)
 	case "git":
 		w, err = git.NewGit(&cfg.GitConfig, filename)
 	case "fs":


### PR DESCRIPTION
This PR introduces support for custom HTTP headers in API requests.
The following changes were made:
1. Added HTTPHeaders Field:
 - Introduced a new HTTPHeaders field in the ApiConfig struct to store custom HTTP headers.
2. Command-Line Argument Parsing:
- Added a new command-line flag --http-headers to accept a comma-separated list of HTTP headers in the format key:value.
3. Initialization of ApiConfig:
- Updated the NewApiStorage function to initialize the HTTPHeaders field correctly.
- Ensured that the HTTPHeaders are copied correctly during the initialization of the ApiConfig struct.
4. Logging:
- Added logging statements to verify that the HTTPHeaders are being parsed and initialized correctly.
5. Request Header Setting:
- Updated the Write method to include the custom HTTP headers in the API requests.

## Example Usage
start netcat
`nc -l 8080`

run

`go run main.go --storage api --environment-name test --debug true --api-endpoint http://localhost:8080 --http-headers="X-Api-Key:secret,Authorization:Bearer token123" --api-key "56789" --api-signature "890"`

result:
```
PUT / HTTP/1.1
Host: localhost:8080
User-Agent: Go-http-client/1.1
Content-Length: 24313
Authorization: Bearer token123
Content-Type: application/json
X-Api-Key: secret
X-Api-Signature: 890
Accept-Encoding: gzip
```