### PR TITLE
Update build-and-push.yaml (#107)

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -38,10 +38,11 @@ jobs:
         id: get-version
         run: |
           branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
+          sanitized_branch=$(echo "${branch}" | tr '/' '-')
           if [ "${branch}" == "main" ]; then
             echo "::set-output name=version::$VERSION"
           else
-            echo "::set-output name=version::${branch}"
+            echo "::set-output name=version::${sanitized_branch}"
           fi
 
       # TODO: Discuss testing strategy and change this step accordingly


### PR DESCRIPTION
fix branch naming issue to enable workflow runs with a prefix in the branch name like "feat/abc", "fix/cde"