### PR TITLE
ran 'go mod tidy' and fixed the logging capabilities of the collector.

### DIFF
--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -172,11 +172,10 @@ func run(cfg *config.Config) {
 	k8Images, err := k8client.GetAllImagesForAllNamespaces()
 	if err != nil {
 		log.Fatal().Stack().Err(err).Msg("Could not retrieve images from K8")
-	} else {
-		// debug log all retrieved images
-		log.Debug().Interface("images", k8Images).Msg("")
-		log.Info().Msg("Images retrieved from K8")
 	}
+	// debug log all retrieved images
+	log.Debug().Interface("images", k8Images).Msg("")
+	log.Info().Msg("Images retrieved from K8")
 
 	// Convert & Clean k8 images to collector images
 	images, err := collector.ConvertImages(k8Images, collectorDefaults, annotationNames, runConfig)

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -52,8 +52,6 @@ func newCommand() *cobra.Command {
 			// Set the logging level based on the debug flag
 			if cfg.Debug {
 				zerolog.SetGlobalLevel(zerolog.DebugLevel)
-			} else {
-				zerolog.SetGlobalLevel(zerolog.InfoLevel)
 			}
 
 			return nil
@@ -184,17 +182,15 @@ func run(cfg *config.Config) {
 	images, err := collector.ConvertImages(k8Images, collectorDefaults, annotationNames, runConfig)
 	if err != nil {
 		log.Fatal().Stack().Err(err).Msg("Could not collect images")
-	} else {
-		log.Debug().Interface("images", images).Msg("")
-		log.Info().Msg("Images collected & converted")
 	}
+	log.Debug().Interface("images", images).Msg("")
+	log.Info().Msg("Images collected & converted")
 
 	// Store images
 	err = collector.Store(images, storage, collector.JsonIndentMarshal)
 	if err != nil {
 		log.Fatal().Stack().Err(err).Msg("Could not store collected images")
-	} else {
-		log.Info().Msg("Images collected and stored")
-		log.Debug().Interface("storage", storage).Msg("using storage")
 	}
+	log.Info().Msg("Images collected and stored")
+	log.Debug().Interface("storage", storage).Msg("using storage")
 }

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -44,7 +44,19 @@ func newCommand() *cobra.Command {
 		Short: ShortDescription,
 		Long:  LongDescription,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return initializeConfig(cmd)
+			// Initialize the configuration
+			if err := initializeConfig(cmd); err != nil {
+				return err
+			}
+
+			// Set the logging level based on the debug flag
+			if cfg.Debug {
+				zerolog.SetGlobalLevel(zerolog.DebugLevel)
+			} else {
+				zerolog.SetGlobalLevel(zerolog.InfoLevel)
+			}
+
+			return nil
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			run(cfg)
@@ -109,11 +121,6 @@ func newCommand() *cobra.Command {
 	c.PersistentFlags().StringVar(&cfg.CollectorImage.Email, "email", "", "Default email to use")
 	c.PersistentFlags().StringVar(&cfg.CollectorImage.NamespaceFilter, "namespace-filter", "", "Default namespace filter to use")
 	c.PersistentFlags().StringVar(&cfg.CollectorImage.NamespaceFilterNegated, "negated_namespace_filter", "", "Default negated namespace filter to use")
-
-	zerolog.SetGlobalLevel(zerolog.InfoLevel)
-	if cfg.Debug {
-		zerolog.SetGlobalLevel(zerolog.DebugLevel)
-	}
 
 	c.PersistentFlags().AddGoFlagSet(flag.CommandLine)
 	return c

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/SDA-SE/image-metadata-collector
 
-go 1.23
+go 1.23.0
+
 toolchain go1.23.2
 
 require (


### PR DESCRIPTION
after upgrading the libraries a simple "go mod tidy" was necessary to get the script running again.
This PR was used to fix the debugging. Since this version debug log level messages can be enabled via parameter. Before, the parameter existed, but was not working because the zerolog.SetGlobalLevel call was outside of the PersistentPreRunE or Run functions, so it ran before the command-line flags were processed.