### PR TITLE
Feature/istio quitquitquit

### DIFF
--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -215,4 +215,11 @@ func run(cfg *config.Config) {
 	}
 	log.Info().Msg("Images collected and stored")
 	log.Debug().Interface("storage", storage).Msg("using storage")
+
+	// Before exiting, send QUITQUITQUIT to Istio sidecar
+	if err := sendQuitQuitQuit(); err != nil {
+		log.Fatal().Err(err).Msg("Error sending QUITQUITQUIT to Istio sidecar")
+	}
+
+	log.Info().Msg("Collector finished")
 }

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -164,9 +164,9 @@ func bindFlags(cmd *cobra.Command, v *viper.Viper) {
 }
 
 // send a terminating QUITQUITQUIT signal to the Istio sidecar
-func sendQuitQuitQuit() error {
+func sendQuitQuitQuit(endpoint string) error {
 	client := &http.Client{Timeout: timeout}
-	resp, err := client.Post(cfg.IstioQuitEndpoint, "text/plain", nil)
+	resp, err := client.Post(endpoint, "text/plain", nil)
 	if err != nil {
 		return fmt.Errorf("failed to send QUITQUITQUIT to Istio sidecar: %v", err)
 	}
@@ -220,7 +220,7 @@ func run(cfg *config.Config) {
 	log.Debug().Interface("storage", storage).Msg("using storage")
 
 	// Before exiting, send QUITQUITQUIT to Istio sidecar
-	if err := sendQuitQuitQuit(); err != nil {
+	if err := sendQuitQuitQuit(cfg.IstioQuitEndpoint); err != nil {
 		log.Fatal().Err(err).Msg("Error sending QUITQUITQUIT to Istio sidecar")
 	}
 

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -27,7 +27,7 @@ const (
 	and 'Pod's
 	for image and team information.
 	`
-	istioQuitEndpoint = "http://localhost:15020/quitquitquit"
+	//istioQuitEndpoint = "http://localhost:15020/quitquitquit"
 	timeout           = 5 * time.Second
 )
 
@@ -125,6 +125,9 @@ func newCommand() *cobra.Command {
 	c.PersistentFlags().StringVar(&cfg.CollectorImage.NamespaceFilter, "namespace-filter", "", "Default namespace filter to use")
 	c.PersistentFlags().StringVar(&cfg.CollectorImage.NamespaceFilterNegated, "negated_namespace_filter", "", "Default negated namespace filter to use")
 
+	// Add istioQuitEndpoint to the config structure
+	c.PersistentFlags().StringVar(&cfg.IstioQuitEndpoint, "istio-quit-endpoint", "http://localhost:15020/quitquitquit", "URL for the Istio sidecar quit endpoint")
+
 	c.PersistentFlags().AddGoFlagSet(flag.CommandLine)
 	return c
 }
@@ -163,7 +166,7 @@ func bindFlags(cmd *cobra.Command, v *viper.Viper) {
 // send a terminating QUITQUITQUIT signal to the Istio sidecar
 func sendQuitQuitQuit() error {
 	client := &http.Client{Timeout: timeout}
-	resp, err := client.Post(istioQuitEndpoint, "text/plain", nil)
+	resp, err := client.Post(cfg.IstioQuitEndpoint, "text/plain", nil)
 	if err != nil {
 		return fmt.Errorf("failed to send QUITQUITQUIT to Istio sidecar: %v", err)
 	}

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -44,7 +44,19 @@ func newCommand() *cobra.Command {
 		Short: ShortDescription,
 		Long:  LongDescription,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return initializeConfig(cmd)
+			// Initialize the configuration
+			if err := initializeConfig(cmd); err != nil {
+				return err
+			}
+
+			// Set the logging level based on the debug flag
+			if cfg.Debug {
+				zerolog.SetGlobalLevel(zerolog.DebugLevel)
+			} else {
+				zerolog.SetGlobalLevel(zerolog.InfoLevel)
+			}
+
+			return nil
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			run(cfg)
@@ -109,11 +121,6 @@ func newCommand() *cobra.Command {
 	c.PersistentFlags().StringVar(&cfg.CollectorImage.Email, "email", "", "Default email to use")
 	c.PersistentFlags().StringVar(&cfg.CollectorImage.NamespaceFilter, "namespace-filter", "", "Default namespace filter to use")
 	c.PersistentFlags().StringVar(&cfg.CollectorImage.NamespaceFilterNegated, "negated_namespace_filter", "", "Default negated namespace filter to use")
-
-	zerolog.SetGlobalLevel(zerolog.InfoLevel)
-	if cfg.Debug {
-		zerolog.SetGlobalLevel(zerolog.DebugLevel)
-	}
 
 	c.PersistentFlags().AddGoFlagSet(flag.CommandLine)
 	return c

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/SDA-SE/image-metadata-collector
 
-go 1.23
+go 1.23.0
+
 toolchain go1.23.2
 
 require (

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,4 +14,6 @@ type Config struct {
 	collector.RunConfig
 
 	Debug bool
+	// added for istioquitquitquit feature
+	IstioQuitEndpoint string
 }


### PR DESCRIPTION
Add graceful Istio sidecar shutdown with sendQuitQuitQuit

- Defined `sendQuitQuitQuit` function to send a POST request to Istio's `quitquitquit` endpoint for graceful sidecar shutdown.
- Called `sendQuitQuitQuit` before program exit to ensure Istio sidecar terminates correctly.
- Included error handling to log and exit if the request fails.

should not get merged into main. PR for generating image