### PR TITLE
fix: Fix a discrepancy between image and image_id

### DIFF
--- a/internal/pkg/kubeclient/kubeclient.go
+++ b/internal/pkg/kubeclient/kubeclient.go
@@ -144,14 +144,14 @@ func (c *Client) GetImages(namespaces *[]Namespace) (*[]Image, error) {
 				// Don't create an image if no image name exists
 				if containerImage == "" && status.Image == "" {
 					continue
-				} else if containerImage == "" {
+				} else if status.Image != "" {
 					imageName = status.Image
 				} else {
 					imageName = containerImage
 				}
 
 				image := Image{
-					Image:         status.Image,
+					Image:         imageName,
 					ImageId:       status.ImageID,
 					NamespaceName: namespace.Name,
 					Labels:        labels,

--- a/internal/pkg/kubeclient/kubeclient.go
+++ b/internal/pkg/kubeclient/kubeclient.go
@@ -151,7 +151,7 @@ func (c *Client) GetImages(namespaces *[]Namespace) (*[]Image, error) {
 				}
 
 				image := Image{
-					Image:         imageName,
+					Image:         status.Image,
 					ImageId:       status.ImageID,
 					NamespaceName: namespace.Name,
 					Labels:        labels,


### PR DESCRIPTION
Because of https://github.com/kubernetes/kubernetes/issues/40062, especially https://github.com/kubernetes/kubernetes/issues/40062#issuecomment-273806013 you can have a difference between container spec and status:

> Yeah, this is due to the fact that we can only choose one image ID, so we use the first repo digest. We could hypothetically have some improved logic here around checking to see if one of the repo digests is "similar" to the pod pull spec and try to use that one, but I'm not sure it's worth the effort here, especially since the SHAs are still the same (which is the more important part, IIRC). Plus, if docker maintains a stable ordering, always using the first guarantees that the full image ID will be identical between different containers running the same image, instead of just the SHA.

```
apiVersion: v1
kind: Pod
metadata:
  ...
spec:
    image: quay.io/kiwigrid/k8s-sidecar:1.28.0
 ...
status:
  containerStatuses:
  - containerID: containerd://9985d0a1253a15816fafad0bcbd72083dd6ed8a9b089c0c7bdf9f6e6e054b010 image: docker.io/kiwigrid/k8s-sidecar:1.28.0 imageID: docker.io/kiwigrid/k8s-sidecar@sha256:4166a019eeafd1f0fef4d867dc5f224f18d84ec8681dbb31f3ca258ecf07bcf2
```

Because of this, we should take both from the status.